### PR TITLE
fix: Add missing quotation mark to gcp_firewall_rule_changes.yaral

### DIFF
--- a/gcp_cloudaudit/gcp_firewall_rule_changes.yaral
+++ b/gcp_cloudaudit/gcp_firewall_rule_changes.yaral
@@ -23,7 +23,7 @@ rule gcp_firewall_rule_changes {
     cis_version = "1.2"
     cis_control = "2.7"
     tactic = "TA0005"
-    technique = "T1562.004
+    technique = "T1562.004"
 
   events:
     $gcp.metadata.vendor_name = "Google Cloud Platform"


### PR DESCRIPTION
`gcp_cloudaudit/gcp_firewall_rule_changes.yaral` has a missing quotation mark that will result in a compilation error like the following when pasted into the rules editor:

```
COMPILATION ERROR: tokenizing: unable to tokenize: literal not terminated
```

This PR adds the missing quotation mark.