### PR TITLE
Added suspicious_rtlo_executable_file

### DIFF
--- a/suspicious/suspicious_rtlo_executable_file.yaral
+++ b/suspicious/suspicious_rtlo_executable_file.yaral
@@ -1,0 +1,22 @@
+rule Suspicious_RTLO_Executable_File {
+  meta:
+      Author = "ag-michael (https://github.com/ag-michael)"
+      severity = "Medium"
+      Description = "Detects an executable being written to disk or executed where a right-to-left-override character in the file name is crafted in a way that can mislead users to believe it has a different extension"
+      Tactic = "TA0005"
+      Technique = "T1036.002"
+      Reference = "https://attack.mitre.org/techniques/T1036/002/"
+      yara_version = "YL2.0" 
+      rule_version = "1.0"
+  events:
+       $endpoint.target.file.full_path = /.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta|vbe|jse|sct|wsf|xsl|cpl|xll)/
+or $endpoint.principal.process.command_line = /.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta|vbe|jse|sct|wsf|xsl|cpl|xll)/
+or $endpoint.target.process.command_line  = /.*‮[\w\d]{2,5}\.(exe|bat|js|vbs|hta|vbe|jse|sct|wsf|xsl|cpl|xll)/
+		
+
+  condition:
+    $endpoint 
+}
+
+    
+


### PR DESCRIPTION
Hi,

This rule detects when a file is written to disk or a commandline contains a right-to-left-override (U202E) character followed by an a string that would deceive users to believe the file has a different extension. For example: legitpic\u202Egpj.exe would appear in windows explorer as legitpicexe.jpg. I have tested this scenario and validated the rule.

P.S: Mind the "invisible" unicode character in the regex if you edit the rule.