### PR TITLE
Updating deprecated fields in GCP rules

### DIFF
--- a/gcp_cloudaudit/gcp_audit_config_changes.yaral
+++ b/gcp_cloudaudit/gcp_audit_config_changes.yaral
@@ -30,7 +30,7 @@ rule gcp_audit_config_changes {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     // exclude system account changes
     not ( $gcp.principal.user.email_addresses = /system.gserviceaccount.com/ )

--- a/gcp_cloudaudit/gcp_cloudsql_config_changes.yaral
+++ b/gcp_cloudaudit/gcp_cloudsql_config_changes.yaral
@@ -30,7 +30,7 @@ rule gcp_cloudsql_config_changes {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
     not ( $gcp.principal.user.email_addresses = /iam.gserviceaccount.com/ )

--- a/gcp_cloudaudit/gcp_custom_role_changes.yaral
+++ b/gcp_cloudaudit/gcp_custom_role_changes.yaral
@@ -32,7 +32,7 @@ rule gcp_custom_role_changes {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
 

--- a/gcp_cloudaudit/gcp_dns_modification.yaral
+++ b/gcp_cloudaudit/gcp_dns_modification.yaral
@@ -32,7 +32,7 @@ rule gcp_dns_modification {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     // exclude system account changes
     not (

--- a/gcp_cloudaudit/gcp_firewall_rule_changes.yaral
+++ b/gcp_cloudaudit/gcp_firewall_rule_changes.yaral
@@ -32,7 +32,7 @@ rule gcp_firewall_rule_changes {
 
    //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
     not $gcp.principal.user.email_addresses = /gserviceaccount.com/

--- a/gcp_cloudaudit/gcp_gcs_iam_changes.yaral
+++ b/gcp_cloudaudit/gcp_gcs_iam_changes.yaral
@@ -30,7 +30,7 @@ rule gcp_gcs_iam_changes {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
     //not ($gcp.principal.user.email_addresses = /iam.gserviceaccount.com/ )

--- a/gcp_cloudaudit/gcp_gcs_public_accessible.yaral
+++ b/gcp_cloudaudit/gcp_gcs_public_accessible.yaral
@@ -35,7 +35,7 @@ rule gcp_gcs_public_accessible {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
     //not ($cis.principal.user.email_addresses = /gserviceaccount.com/

--- a/gcp_cloudaudit/gcp_no_project_api_keys.yaral
+++ b/gcp_cloudaudit/gcp_no_project_api_keys.yaral
@@ -30,7 +30,7 @@ rule gcp_no_project_api_keys {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
 

--- a/gcp_cloudaudit/gcp_vpc_network_changes.yaral
+++ b/gcp_cloudaudit/gcp_vpc_network_changes.yaral
@@ -32,7 +32,7 @@ rule gcp_vpc_network_changes {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
     //not $gcp.principal.user.email_addresses = /add_excluded_accounts_here/

--- a/gcp_cloudaudit/gcp_vpc_network_route_changes.yaral
+++ b/gcp_cloudaudit/gcp_vpc_network_route_changes.yaral
@@ -30,7 +30,7 @@ rule gcp_vpc_network_route_changes {
 
     //capture variables
     $gcp.target.resource.name = $resourceName
-    $gcp.target.cloud.project.name = $projectName
+    $gcp.target.resource_ancestors.name = $projectName
 
     //exclusions
     //not principal.user.email_addresses = /add_excluded_accounts_here/


### PR DESCRIPTION
Updating the deprecated UDM field "Project" as per: https://cloud.google.com/chronicle/docs/reference/udm-field-list