### PR TITLE
Incorrect "allowed" should be "ALLOW"

### DIFF
--- a/soc_prime_rules/threat_hunting/proxy/microsoft_teams_phishing_email.yaral
+++ b/soc_prime_rules/threat_hunting/proxy/microsoft_teams_phishing_email.yaral
@@ -9,7 +9,7 @@ rule microsoft_teams_phishing_email {
     mitre = "T1192, initial_access"
 
   events:
-($selection.security_result.action = "allowed" and ($selection.target.url = "https://us19.campaign-archive.com/?u=0dce22c9638fc90b5c17ea20a&id=6652f42d20" or $selection.target.url = "https://imunodar.com/wp-content/plugins/wp-picaso/Teams"))
+($selection.security_result.action = "ALLOW" and ($selection.target.url = "https://us19.campaign-archive.com/?u=0dce22c9638fc90b5c17ea20a&id=6652f42d20" or $selection.target.url = "https://imunodar.com/wp-content/plugins/wp-picaso/Teams"))
 
   condition:
     $selection

--- a/soc_prime_rules/threat_hunting/proxy/phishing_campaign_using_zoom_invites.yaral
+++ b/soc_prime_rules/threat_hunting/proxy/phishing_campaign_using_zoom_invites.yaral
@@ -9,7 +9,7 @@ rule phishing_campaign_using_zoom_invites {
     mitre = "T1192, initial_access"
 
   events:
-($selection.security_result.action = "allowed" and ($selection.target.url = "https://r.smore.com/c?u=pastell.in/ca07-b36n5-65m-c53b-o26v-62h-e79-t56e-c44?e5=REDACTED[@]company.com" or $selection.target.url = "http://www.pastell.in/ca07-b36n5-65m-c53b-o26v-62h-e79-t56e-c44" or $selection.target.url = "https://logonmicrosftonlinezoomconference.azureedge.net"))
+($selection.security_result.action = "ALLOW" and ($selection.target.url = "https://r.smore.com/c?u=pastell.in/ca07-b36n5-65m-c53b-o26v-62h-e79-t56e-c44?e5=REDACTED[@]company.com" or $selection.target.url = "http://www.pastell.in/ca07-b36n5-65m-c53b-o26v-62h-e79-t56e-c44" or $selection.target.url = "https://logonmicrosftonlinezoomconference.azureedge.net"))
 
   condition:
     $selection

--- a/soc_prime_rules/threat_hunting/proxy/zoom_phishing_email__fake_zoom_login_page___credential_stealer.yaral
+++ b/soc_prime_rules/threat_hunting/proxy/zoom_phishing_email__fake_zoom_login_page___credential_stealer.yaral
@@ -9,7 +9,7 @@ rule zoom_phishing_email_fake_zoom_login_page__credential_stealer {
     mitre = "T1192, initial_access"
 
   events:
-($selection.security_result.action = "allowed" and $selection.target.url = "http://zoom-emergency.myftp.org")
+($selection.security_result.action = "ALLOW" and $selection.target.url = "http://zoom-emergency.myftp.org")
 
   condition:
     $selection


### PR DESCRIPTION
This fixes the Compilation error:
`: got an invalid value for enum field "backstory.SecurityResult.Action"
line: 12 
column: 38-47 `

![CleanShot 2023-12-01 at 12 36 34](https://github.com/chronicle/detection-rules/assets/3722912/6d4f9a22-14ba-4cf4-b7b3-110dbfba4a04)
