### PR TITLE
Add a new YARA-L rule to detect escalated events triggered in GCP SCC for an Identity.

### DIFF
--- a/rules/community/gcp/gcp_identity_event_severity_escalation.yaral
+++ b/rules/community/gcp/gcp_identity_event_severity_escalation.yaral
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ rule Identity_Event_Severity_Escalation {
+
+  meta:
+    author = "Google Cloud Security"
+    description = "Detects when a user experiences a Low severity event followed by Medium severity within 24 hours."
+    rule_name = "Escalated security alerts for specific identity"
+    type = "Alert"
+    platform = "GCP"
+    data_source = "GCP SCC Threat"
+    severity = "High"
+    priority = "High"
+
+  events:
+    // Low severity alert triggered for an identity
+    $low_event.security_result[0].severity = "LOW"
+    $low_event.principal.user.userid = $user_id
+
+    // Medium severity alert triggered for an identity
+    $med_event.security_result[0].severity = "MEDIUM" 
+    $med_event.principal.user.userid = $user_id
+
+    // Low severity event occured before the Medium severity alert
+    $low_event.metadata.event_timestamp.seconds <= $med_event.metadata.event_timestamp.seconds
+
+  match:
+    $user_id over 24h
+
+  outcome:
+    $risk_score = 80
+    $security_category = array_distinct($med_event.security_result.category)
+    $security_category_details = array_distinct($med_event.security_result.category_details)
+    $security_summary = array_distinct($med_event.security_result.summary)
+    $affected_account = array_distinct($med_event.principal.user.userid)
+    $principal_ip_country = array_distinct($med_event.principal.ip_geo_artifact.location.country_or_region)
+    $principal_ip_state = array_distinct($med_event.principal.ip_geo_artifact.location.state)
+    $principal_user_id = array_distinct($med_event.principal.user.userid)
+    
+  condition:
+    $low_event and $med_event  
+}


### PR DESCRIPTION
## Summary:
This PR adds a YARA-L rule to detect and correlate escalated GCP Security Command Center (SCC) events. The rule specifically targets Low to Medium severity escalation associated with a single identity within a 24-hour timeframe.

## Context:
While High and Critical severity alerts typically receive immediate attention from security analysts, Low severity alerts often are deprioritized, while they can serve as precursors to more damaging activities when viewed in context or correlated with other events. This rule aims to:

1. Identify patterns of escalation from Low to Medium severity events for a specific identity.
2. Correlate those events within a 24-hour window to detect potential multi-stage attacks.
*Contextual factors such as resource criticality could be considered to enhance alert prioritization.

## Objective:
By implementing this Multi-Event rule, we can:

1. Correlate SCC events and increase the risk score of correlated anomalous events by prompting more immediate investigation.
2. Improve our Mean Time to Detect (MTTD) for potential security incidents in early stages.
3. Enhance our ability to speed-up the response to attack chains that may begin with seemingly innocuous activities.


## Related Issue(s)
fix #89


