### PR TITLE
Update gcp_firewall_rule_opened_to_world.yaral

### DIFF
--- a/rules/community/gcp/gcp_firewall_rule_opened_to_world.yaral
+++ b/rules/community/gcp/gcp_firewall_rule_opened_to_world.yaral
@@ -34,12 +34,11 @@
   events:
     $gcp.metadata.event_type = "RESOURCE_CREATION"
     $gcp.metadata.log_type = "GCP_CLOUDAUDIT"
-    $gcp.metadata.product_event_type = "beta.compute.firewalls.insert"
+    $gcp.metadata.product_event_type = /compute.firewalls.insert/ nocase
     $gcp.metadata.product_name = "Google Compute Engine"
     $gcp.security_result.action = "ALLOW"
     $gcp.target.resource.attribute.labels["source_ranges"] = "0.0.0.0/0"
     $gcp.security_result.detection_fields["allowed_ipprotocol"] = "all"
-    $gcp.target.resource.attribute.labels["req_disabled"] = "false"
     $gcp.target.resource.attribute.labels["response_status"] = "RUNNING"
 
   outcome:

--- a/rules/community/gcp/gcp_firewall_rule_opened_to_world.yaral
+++ b/rules/community/gcp/gcp_firewall_rule_opened_to_world.yaral
@@ -34,7 +34,7 @@
   events:
     $gcp.metadata.event_type = "RESOURCE_CREATION"
     $gcp.metadata.log_type = "GCP_CLOUDAUDIT"
-    $gcp.metadata.product_event_type = /compute.firewalls.insert/ nocase
+    $gcp.metadata.product_event_type = /compute.firewalls.insert$/ nocase
     $gcp.metadata.product_name = "Google Compute Engine"
     $gcp.security_result.action = "ALLOW"
     $gcp.target.resource.attribute.labels["source_ranges"] = "0.0.0.0/0"


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to this project. Please familiarize yourself with the contribution guide (https://github.com/chronicle/detection-rules/blob/main/CONTRIBUTING.md) and rule style guide (https://github.com/chronicle/detection-rules/blob/main/STYLE_GUIDE.md) if you haven't done so already.


Use GitHub supported keywords to link your pull request to related issues. GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

For example, Resolves #1

-->

## Summary

* Changed the "product_event_type" because I could not find a single log where the event type begins with "beta", only "v1", so this change captures both (and any other) scenarios.
* Removed "req_disabled" because this field did not show up in any of my logs as well. As long as we leave the "response_status" as RUNNING, the rule should retain the same detection logic.

<!--

Write a brief summary of your proposed changes.

The issue(s) that you linked to above should contain a more detailed explanation of these changes.

-->

## Supporting Documentation
When running the following search
`metadata.log_type = "GCP_CLOUDAUDIT" metadata.product_event_type = /compute.firewalls.insert/ nocase`
The only event types that I get are:
![image](https://github.com/user-attachments/assets/da27e146-e93e-46ad-ad51-d6fbb2eb93f3)

Regarding "req_disabled" - not a single event with this field:
![image](https://github.com/user-attachments/assets/b142e545-6d3d-4bf8-889b-8a57032f9693)


<!--

Include any documentation in this section that you think supports your proposed changes.

For example, screenshots from SecOps of detections/alerts (with any confidential/PII data masked/sanitized).

-->
