### PR TITLE
adding gcp unauthorized token endpoint rule

### DIFF
--- a/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
+++ b/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
@@ -31,6 +31,8 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage {
 
   events:
     // This pulls the auth token from application in kubernetes events
+    $app_token.metadata.vendor_name = "Google"
+    $app_token.metadata.log_type = "GCP_CLOUDAUDIT"
     $app_token.metadata.base_labels.log_types = "KUBERNETES_NODE"
     $namespace = $app_token.metadata.base_labels.namespaces
     $traceIdValue = $app_token.about.labels["traceId"]
@@ -38,6 +40,8 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage {
     $auth_token = strings.concat("Authorization: ", $app_token.about.labels["Authorization"])
 
     //This block enriches the auth token statement sinces its missing critical field
+    $k8_enrich.metadata.vendor_name = "Google"
+    $k8_enrich.metadata.log_type = "GCP_CLOUDAUDIT"
     $k8_enrich.metadata.base_labels.log_types = "KUBERNETES_NODE"
     $traceIdValue = $k8_enrich.about[0].labels[0].value
     $k8_enrich.target.ip != ""

--- a/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
+++ b/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
@@ -14,29 +14,22 @@
  * limitations under the License.
  */
 
-rule gcp_unauthorized_gke_pod_token_endpoint_usage{
-  
+rule gcp_unauthorized_gke_pod_token_endpoint_usage {
 
   meta:
-    
     author = "Drew Pilarski - Tempus AI"
     description = "Alerts when an authorization token originating from GKE activity is subsequently used within a command line on an endpoint system, suggesting potential credential exfiltration and reuse."
-    rule_id = ""
+    rule_id = "mr_c9a0cb63-0e35-45eb-8b43-ae48385985dc"
     rule_name = "GCP_Uunauthorized_GKE_Pod_Token_Endpoint_Usage"
-    mitre_attack_tactic = "Lateral Movement"
-    mitre_attack_technique = "Use Alternate Authentication Material (T1550)"
-    mitre_attack_sub_technique = "Application Access Token (T1550.001)"
+    tactic = "TA0008"
+    technique = "T1550.001"
     type = "Alert"
     platform = "GCP"
     data_source = "Cloud Audit Logs"
     severity = "Medium"  // Adjust based on your risk assessment
     priority = "Medium"  // Adjust based on your incident response process
 
-
-
   events:
-    
-    
     // This pulls the auth token from application in kubernetes events
     $app_token.metadata.base_labels.log_types = "KUBERNETES_NODE"
     $namespace = $app_token.metadata.base_labels.namespaces 
@@ -44,7 +37,7 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage{
     $pod_name = $app_token.target.resource_ancestors.attribute.labels["pod_name"]
     $auth_token = strings.concat("Authorization: ", $app_token.about.labels["Authorization"])
 
-    //This block enrichs the auth token statement sinces its missing critical field
+    //This block enriches the auth token statement sinces its missing critical field
     $k8_enrich.metadata.base_labels.log_types = "KUBERNETES_NODE"
     $traceIdValue = $k8_enrich.about[0].labels[0].value 
     $k8_enrich.target.ip != ""
@@ -62,10 +55,9 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage{
     $comp_enrich.metadata.log_type = "CS_EDR"
     $computer_name = $comp_enrich.principal.asset.hostname
     $username = $comp_enrich.target.user.userid 
-    
+
   match:
     $traceIdValue, $auth_token, $computer_name over 24h
-
 
   outcome:
     $token = array_distinct($auth_token)
@@ -79,9 +71,6 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage{
     $traceId = array_distinct($traceIdValue)
     $action = array_distinct($app_token.metadata.product_event_type)
     $account_name = array_distinct($comp_enrich.principal.user.email_addresses)
-    $mitre_attack_tactic = array_distinct("Lateral Movement")
-    $mitre_attack_technique = array_distinct("Use Alternate Authentication Material")
-    $mitre_attack_technique_id = array_distinct("T1550.001")
 
   condition:
     $app_token and $k8_enrich and $comp_token and $comp_enrich

--- a/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
+++ b/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
@@ -32,14 +32,14 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage {
   events:
     // This pulls the auth token from application in kubernetes events
     $app_token.metadata.base_labels.log_types = "KUBERNETES_NODE"
-    $namespace = $app_token.metadata.base_labels.namespaces 
+    $namespace = $app_token.metadata.base_labels.namespaces
     $traceIdValue = $app_token.about.labels["traceId"]
     $pod_name = $app_token.target.resource_ancestors.attribute.labels["pod_name"]
     $auth_token = strings.concat("Authorization: ", $app_token.about.labels["Authorization"])
 
     //This block enriches the auth token statement sinces its missing critical field
     $k8_enrich.metadata.base_labels.log_types = "KUBERNETES_NODE"
-    $traceIdValue = $k8_enrich.about[0].labels[0].value 
+    $traceIdValue = $k8_enrich.about[0].labels[0].value
     $k8_enrich.target.ip != ""
     $pod_ip_1 = $k8_enrich.target.ip[0]
     $email = $k8_enrich.target.user.email_addresses
@@ -48,13 +48,13 @@ rule gcp_unauthorized_gke_pod_token_endpoint_usage {
     $comp_token.metadata.log_type = "CS_EDR"
     $comp_token.target.process.command_line = /Bearer/
     $auth_token = strings.concat("Authorization: ", re.capture($comp_token.target.process.command_line, /Bearer [^\ |^\"]*/))
-    $computer_name = $comp_token.principal.asset.hostname 
+    $computer_name = $comp_token.principal.asset.hostname
     $tar_process = $comp_token.target.process.command_line
 
     $comp_enrich.metadata.event_type = "USER_LOGIN"
     $comp_enrich.metadata.log_type = "CS_EDR"
     $computer_name = $comp_enrich.principal.asset.hostname
-    $username = $comp_enrich.target.user.userid 
+    $username = $comp_enrich.target.user.userid
 
   match:
     $traceIdValue, $auth_token, $computer_name over 24h

--- a/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
+++ b/rules/community/gcp/gcp_unauthorized_gke_pod_token_endpoint_usage.yaral
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rule gcp_unauthorized_gke_pod_token_endpoint_usage{
+  
+
+  meta:
+    
+    author = "Drew Pilarski - Tempus AI"
+    description = "Alerts when an authorization token originating from GKE activity is subsequently used within a command line on an endpoint system, suggesting potential credential exfiltration and reuse."
+    rule_id = ""
+    rule_name = "GCP_Uunauthorized_GKE_Pod_Token_Endpoint_Usage"
+    mitre_attack_tactic = "Lateral Movement"
+    mitre_attack_technique = "Use Alternate Authentication Material (T1550)"
+    mitre_attack_sub_technique = "Application Access Token (T1550.001)"
+    type = "Alert"
+    platform = "GCP"
+    data_source = "Cloud Audit Logs"
+    severity = "Medium"  // Adjust based on your risk assessment
+    priority = "Medium"  // Adjust based on your incident response process
+
+
+
+  events:
+    
+    
+    // This pulls the auth token from application in kubernetes events
+    $app_token.metadata.base_labels.log_types = "KUBERNETES_NODE"
+    $namespace = $app_token.metadata.base_labels.namespaces 
+    $traceIdValue = $app_token.about.labels["traceId"]
+    $pod_name = $app_token.target.resource_ancestors.attribute.labels["pod_name"]
+    $auth_token = strings.concat("Authorization: ", $app_token.about.labels["Authorization"])
+
+    //This block enrichs the auth token statement sinces its missing critical field
+    $k8_enrich.metadata.base_labels.log_types = "KUBERNETES_NODE"
+    $traceIdValue = $k8_enrich.about[0].labels[0].value 
+    $k8_enrich.target.ip != ""
+    $pod_ip_1 = $k8_enrich.target.ip[0]
+    $email = $k8_enrich.target.user.email_addresses
+
+    $comp_token.metadata.event_type = "PROCESS_LAUNCH"
+    $comp_token.metadata.log_type = "CS_EDR"
+    $comp_token.target.process.command_line = /Bearer/
+    $auth_token = strings.concat("Authorization: ", re.capture($comp_token.target.process.command_line, /Bearer [^\ |^\"]*/))
+    $computer_name = $comp_token.principal.asset.hostname 
+    $tar_process = $comp_token.target.process.command_line
+
+    $comp_enrich.metadata.event_type = "USER_LOGIN"
+    $comp_enrich.metadata.log_type = "CS_EDR"
+    $computer_name = $comp_enrich.principal.asset.hostname
+    $username = $comp_enrich.target.user.userid 
+    
+  match:
+    $traceIdValue, $auth_token, $computer_name over 24h
+
+
+  outcome:
+    $token = array_distinct($auth_token)
+    $k8_account = array_distinct($email)
+    $comp_user = array_distinct($username)
+    $hostname = array_distinct($computer_name)
+    $tar_processline = array_distinct($tar_process)
+    $auth_t_namespace = array_distinct($namespace)
+    $pod = array_distinct($pod_name)
+    $pod_ip = array_distinct($pod_ip_1)
+    $traceId = array_distinct($traceIdValue)
+    $action = array_distinct($app_token.metadata.product_event_type)
+    $account_name = array_distinct($comp_enrich.principal.user.email_addresses)
+    $mitre_attack_tactic = array_distinct("Lateral Movement")
+    $mitre_attack_technique = array_distinct("Use Alternate Authentication Material")
+    $mitre_attack_technique_id = array_distinct("T1550.001")
+
+  condition:
+    $app_token and $k8_enrich and $comp_token and $comp_enrich
+}


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to this project. Please familiarize yourself with the contribution guide (https://github.com/chronicle/detection-rules/blob/main/CONTRIBUTING.md) and rule style guide (https://github.com/chronicle/detection-rules/blob/main/STYLE_GUIDE.md) if you haven't done so already.

-->

## Related Issue(s)

Resolves - https://github.com/chronicle/detection-rules/issues/118

<!--

Use GitHub supported keywords to link your pull request to related issues. GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

 


-->

## Summary

This rule detects when an authorization token originating from GKE activity is subsequently used within a command line on an endpoint system, suggesting potential credential exfiltration and reuse

<!--

This rule detects when an authorization token originating from GKE activity is subsequently used within a command line on an endpoint system, suggesting potential credential exfiltration and reuse

The issue(s) that you linked to above should contain a more detailed explanation of these changes.

-->

## Supporting Documentation

https://attack.mitre.org/techniques/T1550/001/

<!--

Include any documentation in this section that you think supports your proposed changes.

For example, screenshots from SecOps of detections/alerts (with any confidential/PII data masked/sanitized).

-->
