### PR TITLE
Update ttp_windows_sharepoint_cve_2025_53770_webshell_succeeded.yaral

### DIFF
--- a/rules/community/microsoft/sharepoint/ttp_windows_sharepoint_cve_2025_53770_webshell_succeeded.yaral
+++ b/rules/community/microsoft/sharepoint/ttp_windows_sharepoint_cve_2025_53770_webshell_succeeded.yaral
@@ -34,7 +34,7 @@ rule ttp_windows_sharepoint_cve_2025_53770_webshell_succeeded {
          $e.metadata.event_type = "STATUS_UPDATE"
       )
       // The file path must be within the SharePoint 15 or 16 hive's LAYOUTS directory.
-      $e.target.file.full_path = /[\x2F\x5C]+(?:Program\ Files|Progra~[1-9])[\x2F\x5C]+(?:Common\ Files|Common~[1-9])[\x2F\x5C]+(?:Microsoft\ Shared|Micros~[1-9])[\x2F\x5C]+(?:Web\ Server\ Extensions|WebSer~[1-9])[\x2F\x5C]+16[\x2F\x5C]+TEMPLATE[\x2F\x5C]+LAYOUTS[\x2F\x5C]+spinstall0\.aspx/ nocase
+      $e.target.file.full_path = /[\x2F\x5C]+(?:Program\ Files|Progra~[1-9])[\x2F\x5C]+(?:Common\ Files|Common~[1-9])[\x2F\x5C]+(?:Microsoft\ Shared|Micros~[1-9])[\x2F\x5C]+(?:Web\ Server\ Extensions|WebSer~[1-9])[\x2F\x5C]+(15|16)[\x2F\x5C]+TEMPLATE[\x2F\x5C]+LAYOUTS[\x2F\x5C]+spinstall0\.aspx/ nocase
       $e.security_result.action = "ALLOW"
       // Capture hostname for match
       $hostname = strings.coalesce($e.principal.asset_id, $e.principal.asset.asset_id, $e.principal.hostname)


### PR DESCRIPTION
adding sharepoint 2013(version 15) directory

<!--

Thank you for your interest in contributing to this project. Please familiarize yourself with the contribution guide (https://github.com/chronicle/detection-rules/blob/main/CONTRIBUTING.md) and rule style guide (https://github.com/chronicle/detection-rules/blob/main/STYLE_GUIDE.md) if you haven't done so already.

-->

## Related Issue(s)

<!--

Use GitHub supported keywords to link your pull request to related issues. GitHub documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue

For example, Resolves #1
Resolves #153 
-->

## Summary
This pull request updates the YARA-L rule `ttp_windows_sharepoint_cve_2025_53770_webshell_succeeded` to include detection for the SharePoint 2013 (version 15) hive path:
- Adds support for the `15` version directory alongside the existing `16`

<!--

Write a brief summary of your proposed changes.

The issue(s) that you linked to above should contain a more detailed explanation of these changes.

-->

## Supporting Documentation
Test cases have been validated for the following paths:

- `C:\Program Files\Common Files\Microsoft Shared\Web Server Extensions\15\TEMPLATE\LAYOUTS\spinstall0.aspx`


<!--

Include any documentation in this section that you think supports your proposed changes.

For example, screenshots from SecOps of detections/alerts (with any confidential/PII data masked/sanitized).

-->
